### PR TITLE
Add support for resources/templates/list method

### DIFF
--- a/resource_response_types.go
+++ b/resource_response_types.go
@@ -10,6 +10,8 @@ type readResourceRequestParams struct {
 type ListResourcesResponse struct {
 	// Resources corresponds to the JSON schema field "resources".
 	Resources []*ResourceSchema `json:"resources" yaml:"resources" mapstructure:"resources"`
+	// Templates corresponds to the JSON schema field "templates".
+	Templates []*ResourceTemplateSchema `json:"templates,omitempty" yaml:"templates,omitempty" mapstructure:"templates,omitempty"`
 	// NextCursor is a cursor for pagination. If not nil, there are more resources available.
 	NextCursor *string `json:"nextCursor,omitempty" yaml:"nextCursor,omitempty" mapstructure:"nextCursor,omitempty"`
 }
@@ -35,4 +37,27 @@ type ResourceSchema struct {
 
 	// The URI of this resource.
 	Uri string `json:"uri" yaml:"uri" mapstructure:"uri"`
+}
+
+// A resource template that the server is capable of reading.
+type ResourceTemplateSchema struct {
+	// Annotations corresponds to the JSON schema field "annotations".
+	Annotations *Annotations `json:"annotations,omitempty" yaml:"annotations,omitempty" mapstructure:"annotations,omitempty"`
+
+	// A description of what this resource template represents.
+	//
+	// This can be used by clients to improve the LLM's understanding of available
+	// resource templates. It can be thought of like a "hint" to the model.
+	Description *string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+
+	// The MIME type of this resource template, if known.
+	MimeType *string `json:"mimeType,omitempty" yaml:"mimeType,omitempty" mapstructure:"mimeType,omitempty"`
+
+	// A human-readable name for this resource template.
+	//
+	// This can be used by clients to populate UI elements.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// The URI template of this resource template.
+	UriTemplate string `json:"uriTemplate" yaml:"uriTemplate" mapstructure:"uriTemplate"`
 }

--- a/server.go
+++ b/server.go
@@ -554,6 +554,7 @@ func (s *Server) Serve() error {
 	pr.SetRequestHandler("prompts/get", s.handlePromptCalls)
 	pr.SetRequestHandler("resources/list", s.handleListResources)
 	pr.SetRequestHandler("resources/read", s.handleResourceCalls)
+	pr.SetRequestHandler("resources/templates/list", s.handleListResourceTemplates)
 	err := pr.Connect(s.transport)
 	if err != nil {
 		return err
@@ -874,6 +875,29 @@ func (s *Server) handleResourceCalls(ctx context.Context, req *transport.BaseJSO
 		return nil, errors.Wrapf(err, "unknown prompt: %s", req.Method)
 	}
 	return resourceToUse.Handler(ctx), nil
+}
+
+func (s *Server) handleListResourceTemplates(ctx context.Context, request *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {
+	type resourceTemplateRequestParams struct {
+		Cursor *string `json:"cursor"`
+	}
+	var params resourceTemplateRequestParams
+	if request.Params == nil {
+		params = resourceTemplateRequestParams{}
+	} else {
+		err := json.Unmarshal(request.Params, &params)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal arguments")
+		}
+	}
+
+	// For now, we're just returning an empty list of templates
+	// In the future, resource templates could be registered with the server
+	return ListResourcesResponse{
+		Resources: []*ResourceSchema{},
+		Templates: []*ResourceTemplateSchema{},
+		NextCursor: nil,
+	}, nil
 }
 
 func (s *Server) handlePing(ctx context.Context, request *transport.BaseJSONRPCRequest, extra protocol.RequestHandlerExtra) (transport.JsonRpcBody, error) {

--- a/server.go
+++ b/server.go
@@ -819,6 +819,7 @@ func (s *Server) handleListResources(ctx context.Context, request *transport.Bas
 
 	return ListResourcesResponse{
 		Resources: resourcesToReturn,
+		Templates: []*ResourceTemplateSchema{}, // Empty array for now
 		NextCursor: func() *string {
 			if s.paginationLimit != nil && len(resourcesToReturn) >= *s.paginationLimit {
 				toString := base64.StdEncoding.EncodeToString([]byte(resourcesToReturn[len(resourcesToReturn)-1].Uri))


### PR DESCRIPTION
## Summary
- Add handler for `resources/templates/list` method
- Add `ResourceTemplateSchema` struct to handle template data in responses

## Test plan
- Verify the handler returns expected response format
- Confirm templates field is included in ListResourcesResponse

🤖 Generated with [Claude Code](https://claude.ai/code)